### PR TITLE
fix encoding problems, add pdftotext "-enc UTF-8" arg

### DIFF
--- a/lib/extract-text.js
+++ b/lib/extract-text.js
@@ -26,6 +26,8 @@ module.exports.process = function(pdf_path, options, callback) {
 
 
   args.push('-layout');
+  args.push('-enc');
+  args.push('UTF-8');
   args.push(pdf_path);
   args.push('-');
 


### PR DESCRIPTION
Hi

I had a problem with encoding when using PDF documents with umlauts. pdftetext has the "-enc" option to set the encoding of the text output. Adding this helps solving my problem with encoding, maybe consider to include it? 

Btw: I tried

```
args.push('-enc UTF-8'); 
```

first, but this resulted in an error. Maybe there's a nicer way to add this code?

Thanks for npm pdf-to-text, which is very handy!
