### PR TITLE
fixing duplicate callback invocation

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -18,8 +18,7 @@ module.exports.process = function(pdf_path, callback) {
   stderr.setEncoding('utf8');
 
   stderr.on('data', function(data) {
-    console.log('data ' + data)
-    return callback(data, null);
+    console.warn('pdf-to-text', 'info.process', '[stderr data]', data);
   });
 
   // buffer the stdout output
@@ -28,11 +27,8 @@ module.exports.process = function(pdf_path, callback) {
   });
 
   stdout.on('close', function(code) {
-    if (code) {
-      callback('pdfinfo end with code ' + code, null);
-    }
-    output = convertOutputToObject(output);
-    callback(null, output);
+    if (code) return callback('pdfinfo end with code ' + code, null);
+    callback(null, convertOutputToObject(output));
   });
 };
 /**


### PR DESCRIPTION
- resolving error handling issues
- avoid duplicate invocation of callback
- avoid invocation of callback on standard error out

Noticed similar issue on previous requests. Recommend testing with empty files, non-PDF files, and bad pointers to files. These situations result in runtime errors that cannot be recovered from. 
