### PR TITLE
fix double callback on error

### DIFF
--- a/lib/extract-text.js
+++ b/lib/extract-text.js
@@ -8,7 +8,7 @@ var spawn = require('child_process').spawn;
  * @return {[type]}            [description]
  */
 module.exports.process = function(pdf_path, options, callback) {
-  
+
   var args = [];
   if (typeof options !== 'function') {
     if (options && options.from && !isNaN(options.from)) {
@@ -56,7 +56,7 @@ module.exports.process = function(pdf_path, options, callback) {
       return;
     }
     if (code) {
-      callback('pdftotext end with code ' + code, null);
+      return callback('pdftotext end with code ' + code, null);
     }
     callback(null, output);
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -29,7 +29,7 @@ module.exports.process = function(pdf_path, callback) {
 
   stdout.on('close', function(code) {
     if (code) {
-      callback('pdfinfo end with code ' + code, null);
+      return callback('pdfinfo end with code ' + code, null);
     }
     output = convertOutputToObject(output);
     callback(null, output);


### PR DESCRIPTION
If "err" is falsey but "code" is truthy, callback still gets called twice. This fixes the double callback in that case.
