### PR TITLE
modified extract-text.js to allow all possible options

### DIFF
--- a/lib/extract-text.js
+++ b/lib/extract-text.js
@@ -11,6 +11,17 @@ module.exports.process = function(pdf_path, options, callback) {
 
   var args = [];
   if (typeof options !== 'function') {
+
+    for (option in options) {
+      //puse all provided options to the comand line arguments
+      if (!isNaN(options[option]) && option != 'from' && option != 'to') {
+        args.push('-' + option)
+        args.push(options[option])
+      }
+    }
+
+    //following two if statements and the from and to options 
+    // should be deprecated - instead of from and to f and l should be used
     if (options && options.from && !isNaN(options.from)) {
       args.push('-f');
       args.push(options.from)


### PR DESCRIPTION
modified extract-text.js to allow all possible options that pdftotext program takes

Original from and to options should be deprecated and use -f and -l instead respectively.